### PR TITLE
Use dedicated class loader

### DIFF
--- a/Common/src/main/java/com/cerbon/cerbons_api/platform/Services.java
+++ b/Common/src/main/java/com/cerbon/cerbons_api/platform/Services.java
@@ -13,7 +13,7 @@ public class Services {
     public static final ICapabilityHelper PLATFORM_CAPABILITY = load(ICapabilityHelper.class);
 
     public static <T> T load(Class<T> clazz) {
-        final T loadedService = ServiceLoader.load(clazz)
+        final T loadedService = ServiceLoader.load(clazz, clazz.getClassLoader())
                 .findFirst()
                 .orElseThrow(() -> new NullPointerException("Failed to load service for " + clazz.getName()));
         Constants.LOGGER.debug("Loaded {} for service {}", loadedService, clazz);


### PR DESCRIPTION
In continuation of https://github.com/CERBON-MODS/CERBONs-API/issues/4

My OS is MacOS and for some reason my `serviceloader` was unable to load these interface.
And only when I used exactly this class loader these classes were found and mod loaded.
To add some details, when I was inspecting `serviceloader` through Idea debugger there are actually weren't your packages at all in the available list but when I switch class loader it appeared and started to work

This issue was found on this modpack - https://www.curseforge.com/minecraft/modpacks/craft-to-exile-2
